### PR TITLE
Improve autosave reliability with scoped keys, TTL support, and error handling

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -7,3 +7,7 @@ require('@angular/localize/init');
   unobserve: jest.fn(),
   disconnect: jest.fn(),
 }));
+
+if (typeof structuredClone === 'undefined') {
+  globalThis.structuredClone = (obj: any) => JSON.parse(JSON.stringify(obj));
+}

--- a/src/web/app/components/question-submission-form/question-submission-form-model.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form-model.ts
@@ -40,6 +40,8 @@ export interface QuestionSubmissionFormModel {
   recipientType: FeedbackParticipantType;
   recipientList: FeedbackResponseRecipient[];
   recipientSubmissionForms: FeedbackResponseRecipientSubmissionFormModel[];
+  // original recipient submission forms stores the last submitted state of the recipient submission forms.
+  originalRecipientSubmissionForms: FeedbackResponseRecipientSubmissionFormModel[];
 
   numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting;
   customNumberOfEntitiesToGiveFeedbackTo: number;

--- a/src/web/app/components/question-submission-form/question-submission-form.component.ts
+++ b/src/web/app/components/question-submission-form/question-submission-form.component.ts
@@ -130,7 +130,10 @@ export class QuestionSubmissionFormComponent implements DoCheck {
 
   isMCQDropDownEnabled: boolean = false;
   isSaved: boolean = false;
-  hasResponseChanged: boolean = false;
+
+  get hasResponseChanged(): boolean {
+    return Array.from(this.model.hasResponseChangedForRecipients.values()).some(Boolean);
+  }
 
   @Input()
   formMode: QuestionSubmissionFormMode = QuestionSubmissionFormMode.FIXED_RECIPIENT;
@@ -166,7 +169,6 @@ export class QuestionSubmissionFormComponent implements DoCheck {
 
       this.model.isTabExpandedForRecipients.set(recipient.recipientIdentifier, true);
     });
-    this.hasResponseChanged = Array.from(this.model.hasResponseChangedForRecipients.values()).some((value) => value);
   }
 
   @Input()
@@ -193,7 +195,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
   responsesSave: EventEmitter<QuestionSubmissionFormModel> = new EventEmitter();
 
   @Output()
-  autoSave: EventEmitter<{ id: string, model: QuestionSubmissionFormModel }> = new EventEmitter();
+  autoSave: EventEmitter<QuestionSubmissionFormModel> = new EventEmitter();
 
   @Output()
   resetFeedback: EventEmitter<QuestionSubmissionFormModel> = new EventEmitter<QuestionSubmissionFormModel>();
@@ -221,6 +223,7 @@ export class QuestionSubmissionFormComponent implements DoCheck {
     recipientType: FeedbackParticipantType.STUDENTS,
     recipientList: [],
     recipientSubmissionForms: [],
+    originalRecipientSubmissionForms: [],
 
     questionType: FeedbackQuestionType.TEXT,
     questionDetails: {
@@ -248,8 +251,6 @@ export class QuestionSubmissionFormComponent implements DoCheck {
   visibilityStateMachine: VisibilityStateMachine;
   isEveryRecipientSorted: boolean = false;
 
-  autosaveTimeout: any;
-
   constructor(private feedbackQuestionsService: FeedbackQuestionsService,
     private feedbackResponseService: FeedbackResponsesService) {
     this.visibilityStateMachine =
@@ -275,39 +276,18 @@ export class QuestionSubmissionFormComponent implements DoCheck {
       this.sortRecipientsByName();
     }
 
-    if (this.model.recipientSubmissionForms.some(
-      (response) => response.responseId.length > 0) && !this.isSaved) {
-      this.isSaved = true;
-    }
-
-    if (this.hasResponseChanged) {
-      this.isSaved = false;
-    }
+    this.isSaved = this.model
+      .recipientSubmissionForms.some((form) => form.responseId.length > 0) && !this.hasResponseChanged;
 
     if (this.isSubmitAllClicked) {
-      if (this.model.recipientSubmissionForms.some((response) => response.responseId.length > 0)) {
-        this.isSaved = true;
-      } else if (this.model.recipientSubmissionForms.every((form) => form.responseId.length === 0)) {
-        this.isSaved = false;
-      }
-
       this.model.hasResponseChangedForRecipients.forEach((_hasResponseChanged: boolean, recipientId: string) => {
         this.model.hasResponseChangedForRecipients.set(recipientId, false);
       });
     }
-
-    this.model.hasResponseChangedForRecipients.forEach((hasResponseChanged: boolean) => {
-      if (hasResponseChanged) {
-        this.isSaved = false;
-      }
-    });
   }
 
   resetForm(): void {
     this.resetFeedback.emit(this.model);
-    this.isSaved = true;
-    this.hasResponseChanged = false;
-    clearTimeout(this.autosaveTimeout);
   }
 
   toggleQuestionTab(): void {
@@ -385,6 +365,13 @@ export class QuestionSubmissionFormComponent implements DoCheck {
 
       return firstRecipientIndex - secondRecipientIndex;
     });
+    this.model.originalRecipientSubmissionForms.sort((firstRecipient: FeedbackResponseRecipientSubmissionFormModel,
+      secondRecipient: FeedbackResponseRecipientSubmissionFormModel) => {
+      const firstRecipientIndex: number = indexes.get(firstRecipient.recipientIdentifier) || Number.MAX_SAFE_INTEGER;
+      const secondRecipientIndex: number = indexes.get(secondRecipient.recipientIdentifier) || Number.MAX_SAFE_INTEGER;
+
+      return firstRecipientIndex - secondRecipientIndex;
+    });
     this.isEveryRecipientSorted = true;
   }
 
@@ -438,25 +425,23 @@ export class QuestionSubmissionFormComponent implements DoCheck {
    * Triggers the change of the recipient submission form.
    */
   triggerRecipientSubmissionFormChange(index: number, field: string, data: any): void {
-    if (!this.isFormsDisabled) {
-      this.isSubmitAllClickedChange.emit(false);
-      this.model.hasResponseChangedForRecipients.set(this.model.recipientList[index].recipientIdentifier, true);
-
-      this.model.recipientSubmissionForms[index] =
-      {
-        ...this.model.recipientSubmissionForms[index],
-        [field]: data,
-      };
-
-      this.updateIsValidByQuestionConstraint();
-      this.formModelChange.emit(this.model);
-
-      this.autoSave.emit({ id: this.model.feedbackQuestionId, model: this.model });
-      clearTimeout(this.autosaveTimeout);
-      this.autosaveTimeout = setTimeout(() => {
-        this.hasResponseChanged = true;
-      }, 100); // 0.1 second to prevent people from trying to immediately reset before autosave kicks in
+    if (this.isFormsDisabled) {
+      return;
     }
+
+    this.isSubmitAllClickedChange.emit(false);
+    this.model.hasResponseChangedForRecipients.set(this.model.recipientList[index].recipientIdentifier, true);
+
+    this.model.recipientSubmissionForms[index] =
+    {
+      ...this.model.recipientSubmissionForms[index],
+      [field]: data,
+    };
+
+    this.updateIsValidByQuestionConstraint();
+    this.formModelChange.emit(this.model);
+
+    this.autoSave.emit(this.model);
   }
 
   updateIsValidByQuestionConstraint(): void {
@@ -545,13 +530,6 @@ export class QuestionSubmissionFormComponent implements DoCheck {
    * Triggers saving of responses for the specific question.
    */
   saveFeedbackResponses(): void {
-    clearTimeout(this.autosaveTimeout);
-    this.isSaved = true;
-    this.hasResponseChanged = false;
-    this.model.hasResponseChangedForRecipients.forEach(
-        (_hasResponseChangedForRecipient: boolean, recipientId: string) => {
-        this.model.hasResponseChangedForRecipients.set(recipientId, false);
-    });
     this.responsesSave.emit(this.model);
   }
 

--- a/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
+++ b/src/web/app/pages-help/instructor-help-page/instructor-help-questions-section/instructor-help-questions-data.ts
@@ -1533,6 +1533,20 @@ export const EXAMPLE_RESPONDER_RUBRIC_SUBMISSION_FORM_MODEL: QuestionSubmissionF
       isValid: true,
     },
   ],
+  originalRecipientSubmissionForms: [
+    {
+      responseId: 'response1',
+      recipientIdentifier: 'alice',
+      responseDetails: { questionType: FeedbackQuestionType.RUBRIC, answer: [0, 2] } as FeedbackRubricResponseDetails,
+      isValid: true,
+    },
+    {
+      responseId: 'response2',
+      recipientIdentifier: 'bob',
+      responseDetails: { questionType: FeedbackQuestionType.RUBRIC, answer: [1, 3] } as FeedbackRubricResponseDetails,
+      isValid: true,
+    },
+  ],
   customNumberOfEntitiesToGiveFeedbackTo: 0,
   feedbackQuestionId: '',
   questionNumber: 1,

--- a/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
+++ b/src/web/app/pages-session/session-submission-page/__snapshots__/session-submission-page.component.spec.ts.snap
@@ -2,14 +2,12 @@
 
 exports[`SessionSubmissionPageComponent should snap when feedback session questions have failed to load 1`] = `
 <tm-session-submission-page
-  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
-  autoSaveDelay={[Function Number]}
-  autoSaveTimeout="undefined"
+  autosaveService={[Function AutosaveService]}
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
@@ -48,7 +46,6 @@ exports[`SessionSubmissionPageComponent should snap when feedback session questi
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
-  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName=""
@@ -165,14 +162,12 @@ exports[`SessionSubmissionPageComponent should snap when feedback session questi
 
 exports[`SessionSubmissionPageComponent should snap when saving responses 1`] = `
 <tm-session-submission-page
-  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
-  autoSaveDelay={[Function Number]}
-  autoSaveTimeout="undefined"
+  autosaveService={[Function AutosaveService]}
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
@@ -211,7 +206,6 @@ exports[`SessionSubmissionPageComponent should snap when saving responses 1`] = 
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
-  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName=""
@@ -325,14 +319,12 @@ exports[`SessionSubmissionPageComponent should snap when saving responses 1`] = 
 
 exports[`SessionSubmissionPageComponent should snap with default fields 1`] = `
 <tm-session-submission-page
-  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
-  autoSaveDelay={[Function Number]}
-  autoSaveTimeout="undefined"
+  autosaveService={[Function AutosaveService]}
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
@@ -371,7 +363,6 @@ exports[`SessionSubmissionPageComponent should snap with default fields 1`] = `
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
-  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName=""
@@ -485,14 +476,12 @@ exports[`SessionSubmissionPageComponent should snap with default fields 1`] = `
 
 exports[`SessionSubmissionPageComponent should snap with feedback session and user details 1`] = `
 <tm-session-submission-page
-  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
-  autoSaveDelay={[Function Number]}
-  autoSaveTimeout="undefined"
+  autosaveService={[Function AutosaveService]}
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
@@ -531,7 +520,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session and us
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
-  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail={[Function String]}
   personName={[Function String]}
@@ -778,14 +766,12 @@ exports[`SessionSubmissionPageComponent should snap with feedback session and us
 
 exports[`SessionSubmissionPageComponent should snap with feedback session question submission forms 1`] = `
 <tm-session-submission-page
-  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
-  autoSaveDelay={[Function Number]}
-  autoSaveTimeout={[Function Number]}
+  autosaveService={[Function AutosaveService]}
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
@@ -824,7 +810,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
-  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName=""
@@ -1589,7 +1574,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
                   </button>
                   <button
                     class="btn btn-warning float-end"
-                    disabled=""
                     ngbtooltip="Reset your responses for this question to the last submitted state."
                     type="button"
                   >
@@ -3891,14 +3875,12 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
 
 exports[`SessionSubmissionPageComponent should snap with feedback session question submission forms when disabled 1`] = `
 <tm-session-submission-page
-  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
-  autoSaveDelay={[Function Number]}
-  autoSaveTimeout="undefined"
+  autosaveService={[Function AutosaveService]}
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
@@ -3937,7 +3919,6 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
-  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName=""
@@ -7034,14 +7015,12 @@ exports[`SessionSubmissionPageComponent should snap with feedback session questi
 
 exports[`SessionSubmissionPageComponent should snap with user that is logged in and using session link 1`] = `
 <tm-session-submission-page
-  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
-  autoSaveDelay={[Function Number]}
-  autoSaveTimeout="undefined"
+  autosaveService={[Function AutosaveService]}
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
@@ -7080,7 +7059,6 @@ exports[`SessionSubmissionPageComponent should snap with user that is logged in 
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
-  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName={[Function String]}
@@ -7195,14 +7173,12 @@ exports[`SessionSubmissionPageComponent should snap with user that is logged in 
 
 exports[`SessionSubmissionPageComponent should snap with user that is not logged in and using session link 1`] = `
 <tm-session-submission-page
-  AUTOSAVE_KEY={[Function String]}
   FeedbackQuestionType={[Function Object]}
   FeedbackSessionSubmissionStatus={[Function Object]}
   Intent={[Function Object]}
   allSessionViews={[Function Object]}
   authService={[Function AuthService]}
-  autoSaveDelay={[Function Number]}
-  autoSaveTimeout="undefined"
+  autosaveService={[Function AutosaveService]}
   backendUrl={[Function String]}
   castAsSelectElement={[Function Function]}
   commentService={[Function FeedbackResponseCommentService]}
@@ -7241,7 +7217,6 @@ exports[`SessionSubmissionPageComponent should snap with user that is not logged
   moderatedQuestionId=""
   navigationService={[Function NavigationService]}
   ngbModal={[Function _NgbModal]}
-  originalQuestionSubmissionForms={[Function Array]}
   pageScrollService={[Function _PageScrollService]}
   personEmail=""
   personName={[Function String]}

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.html
@@ -124,7 +124,7 @@
                                           [currentSelectedSessionView]="currentSelectedSessionView"
                                           [recipientId]="entry.key"
                                           (resetFeedback)="resetFeedbackResponses([$event], entry.key)"
-                                          (autoSave)="handleAutoSave($event)"
+                                          (autoSave)="handleAutosave($event)"
               ></tm-question-submission-form>
             </ng-container>
           </ng-container>
@@ -157,7 +157,7 @@
                                       [isQuestionCountOne]="isQuestionCountOne"
                                       [(isSubmitAllClicked)]="isSubmitAllClicked"
                                       (resetFeedback)="resetFeedbackResponses([$event], null)"
-                                      (autoSave)="handleAutoSave($event)"
+                                      (autoSave)="handleAutosave($event)"
           ></tm-question-submission-form>
         </ng-container>
       </ng-container>
@@ -174,7 +174,7 @@
                                    [(isSubmitAllClicked)]="isSubmitAllClicked"
                                    [currentSelectedSessionView]="currentSelectedSessionView"
                                    (resetFeedback)="resetFeedbackResponses([$event], null)"
-                                   (autoSave)="handleAutoSave($event)"
+                                   (autoSave)="handleAutosave($event)"
       ></tm-question-submission-form>
     </ng-container>
     <div class="row" *ngIf="questionsNeedingSubmission.length === 0">

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.spec.ts
@@ -298,6 +298,7 @@ describe('SessionSubmissionPageComponent', () => {
     giverType: FeedbackParticipantType.STUDENTS,
     recipientType: FeedbackParticipantType.OWN_TEAM,
     recipientList: [{ recipientName: 'Gene Harris', recipientIdentifier: 'gene-harris-id' }],
+    originalRecipientSubmissionForms: [testMcqRecipientSubmissionForm],
     recipientSubmissionForms: [testMcqRecipientSubmissionForm],
     numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
     customNumberOfEntitiesToGiveFeedbackTo: 5,
@@ -325,6 +326,7 @@ describe('SessionSubmissionPageComponent', () => {
     giverType: FeedbackParticipantType.INSTRUCTORS,
     recipientType: FeedbackParticipantType.TEAMS,
     recipientList: [],
+    originalRecipientSubmissionForms: [],
     recipientSubmissionForms: [],
     numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
     customNumberOfEntitiesToGiveFeedbackTo: 5,
@@ -351,6 +353,7 @@ describe('SessionSubmissionPageComponent', () => {
     giverType: FeedbackParticipantType.STUDENTS,
     recipientType: FeedbackParticipantType.INSTRUCTORS,
     recipientList: [{ recipientName: 'Gene Harris', recipientIdentifier: 'gene-harris-id' }],
+    originalRecipientSubmissionForms: [testTextRecipientSubmissionForm],
     recipientSubmissionForms: [testTextRecipientSubmissionForm],
     numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
     customNumberOfEntitiesToGiveFeedbackTo: 5,
@@ -382,6 +385,7 @@ describe('SessionSubmissionPageComponent', () => {
     giverType: FeedbackParticipantType.INSTRUCTORS,
     recipientType: FeedbackParticipantType.STUDENTS,
     recipientList: [{ recipientName: 'Barry Harris', recipientIdentifier: 'barry-harris-id' }],
+    originalRecipientSubmissionForms: [testMsqRecipientSubmissionForm],
     recipientSubmissionForms: [testMsqRecipientSubmissionForm],
     numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
     customNumberOfEntitiesToGiveFeedbackTo: 5,
@@ -410,6 +414,7 @@ describe('SessionSubmissionPageComponent', () => {
     giverType: FeedbackParticipantType.INSTRUCTORS,
     recipientType: FeedbackParticipantType.STUDENTS,
     recipientList: [{ recipientName: 'Barry Harris', recipientIdentifier: 'barry-harris-id' }],
+    originalRecipientSubmissionForms: [testNumscaleRecipientSubmissionForm],
     recipientSubmissionForms: [testNumscaleRecipientSubmissionForm],
     numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
     customNumberOfEntitiesToGiveFeedbackTo: 5,
@@ -445,6 +450,7 @@ describe('SessionSubmissionPageComponent', () => {
     giverType: FeedbackParticipantType.INSTRUCTORS,
     recipientType: FeedbackParticipantType.STUDENTS,
     recipientList: [{ recipientName: 'Barry Harris', recipientIdentifier: 'barry-harris-id' }],
+    originalRecipientSubmissionForms: [testConstsumRecipientSubmissionForm],
     recipientSubmissionForms: [testConstsumRecipientSubmissionForm],
     numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
     customNumberOfEntitiesToGiveFeedbackTo: 5,
@@ -475,6 +481,7 @@ describe('SessionSubmissionPageComponent', () => {
     giverType: FeedbackParticipantType.INSTRUCTORS,
     recipientType: FeedbackParticipantType.STUDENTS,
     recipientList: [{ recipientName: 'Barry Harris', recipientIdentifier: 'barry-harris-id' }],
+    originalRecipientSubmissionForms: [testContribRecipientSubmissionForm],
     recipientSubmissionForms: [testContribRecipientSubmissionForm],
     numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
     customNumberOfEntitiesToGiveFeedbackTo: 5,
@@ -509,6 +516,7 @@ describe('SessionSubmissionPageComponent', () => {
     giverType: FeedbackParticipantType.INSTRUCTORS,
     recipientType: FeedbackParticipantType.STUDENTS,
     recipientList: [{ recipientName: 'Barry Harris', recipientIdentifier: 'barry-harris-id' }],
+    originalRecipientSubmissionForms: [testRubricRecipientSubmissionForm],
     recipientSubmissionForms: [testRubricRecipientSubmissionForm],
     numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
     customNumberOfEntitiesToGiveFeedbackTo: 5,
@@ -539,6 +547,7 @@ describe('SessionSubmissionPageComponent', () => {
     giverType: FeedbackParticipantType.INSTRUCTORS,
     recipientType: FeedbackParticipantType.STUDENTS,
     recipientList: [{ recipientName: 'Barry Harris', recipientIdentifier: 'barry-harris-id' }],
+    originalRecipientSubmissionForms: [testRankOptionsRecipientSubmissionForm],
     recipientSubmissionForms: [testRankOptionsRecipientSubmissionForm],
     numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
     customNumberOfEntitiesToGiveFeedbackTo: 5,
@@ -571,6 +580,7 @@ describe('SessionSubmissionPageComponent', () => {
     giverType: FeedbackParticipantType.INSTRUCTORS,
     recipientType: FeedbackParticipantType.STUDENTS,
     recipientList: [{ recipientName: 'Barry Harris', recipientIdentifier: 'barry-harris-id' }],
+    originalRecipientSubmissionForms: [testRankRecipientsRecipientSubmissionForm],
     recipientSubmissionForms: [testRankRecipientsRecipientSubmissionForm],
     numberOfEntitiesToGiveFeedbackToSetting: NumberOfEntitiesToGiveFeedbackToSetting.UNLIMITED,
     customNumberOfEntitiesToGiveFeedbackTo: 5,
@@ -656,6 +666,7 @@ describe('SessionSubmissionPageComponent', () => {
   }));
 
   beforeEach(() => {
+    localStorage.clear(); // TODO check if necessary
     fixture = TestBed.createComponent(SessionSubmissionPageComponent);
     authService = TestBed.inject(AuthService);
     navService = TestBed.inject(NavigationService);
@@ -743,6 +754,7 @@ describe('SessionSubmissionPageComponent', () => {
     component.isFeedbackSessionLoading = false;
     component.isFeedbackSessionQuestionsLoading = false;
     fixture.detectChanges();
+
     expect(fixture).toMatchSnapshot();
   });
 
@@ -1070,7 +1082,12 @@ describe('SessionSubmissionPageComponent', () => {
     const testResponseDetails2: FeedbackTextResponseDetails = { answer: '', questionType: FeedbackQuestionType.TEXT };
     const testQuestionSubmissionForm1: QuestionSubmissionFormModel = deepCopy(testMcqQuestionSubmissionForm);
     const testQuestionSubmissionForm2: QuestionSubmissionFormModel = deepCopy(testTextQuestionSubmissionForm);
+    testQuestionSubmissionForm1.hasResponseChangedForRecipients = new Map<string, boolean>([
+      ['barry-harris-id', true],
+      ['random-id', false],
+    ]);
     testQuestionSubmissionForm1.recipientSubmissionForms[0].responseDetails = testResponseDetails1;
+    testQuestionSubmissionForm2.hasResponseChangedForRecipients = new Map<string, boolean>();
     testQuestionSubmissionForm2.recipientSubmissionForms[0].responseDetails = testResponseDetails2;
     component.questionSubmissionForms = [testQuestionSubmissionForm1, testQuestionSubmissionForm2];
 
@@ -1084,7 +1101,6 @@ describe('SessionSubmissionPageComponent', () => {
     jest.spyOn(feedbackResponseCommentService, 'createComment').mockReturnValue(of(testComment));
     jest.spyOn(feedbackResponseCommentService, 'updateComment').mockReturnValue(of(testComment));
     jest.spyOn(ngbModal, 'open').mockReturnValue(mockModalRef);
-
     component.saveFeedbackResponses(component.questionSubmissionForms, true, null);
 
     expect(responseSpy).toHaveBeenCalledTimes(2);
@@ -1122,6 +1138,8 @@ describe('SessionSubmissionPageComponent', () => {
     });
     expect(mockModalRef.componentInstance.notYetAnsweredQuestions).toHaveLength(1);
     expect(mockModalRef.componentInstance.failToSaveQuestions).toEqual({});
+    expect(component.questionSubmissionForms[0].hasResponseChangedForRecipients.get('barry-harris-id')).toBe(false);
+    expect(component.questionSubmissionForms[0].hasResponseChangedForRecipients.get('random-id')).toBe(false);
   });
 
   it('should not save invalid feedback responses', () => {
@@ -1130,7 +1148,12 @@ describe('SessionSubmissionPageComponent', () => {
     const testResponseDetails2: any = deepCopy(testConstsumRecipientSubmissionForm.responseDetails);
     const testQuestionSubmissionForm1: QuestionSubmissionFormModel = deepCopy(testMcqQuestionSubmissionForm);
     const testQuestionSubmissionForm2: QuestionSubmissionFormModel = deepCopy(testConstsumQuestionSubmissionForm);
+    testQuestionSubmissionForm1.hasResponseChangedForRecipients = new Map<string, boolean>();
     testQuestionSubmissionForm1.recipientSubmissionForms[0].responseDetails = testResponseDetails1;
+    testQuestionSubmissionForm2.hasResponseChangedForRecipients = new Map<string, boolean>([
+      ['barry-harris-id', true],
+      ['random-id', false],
+    ]);
     testQuestionSubmissionForm2.recipientSubmissionForms[0].responseDetails = testResponseDetails2;
     // invalid response
     testQuestionSubmissionForm2.recipientSubmissionForms[0].isValid = false;
@@ -1173,6 +1196,8 @@ describe('SessionSubmissionPageComponent', () => {
     expect(mockModalRef.componentInstance.failToSaveQuestions).toEqual({
       [testQuestionSubmissionForm2.questionNumber]: 'Invalid responses provided. Please check question constraints.',
     });
+    expect(component.questionSubmissionForms[1].hasResponseChangedForRecipients.get('barry-harris-id')).toBe(true);
+    expect(component.questionSubmissionForms[1].hasResponseChangedForRecipients.get('random-id')).toBe(false);
   });
 
   it('should create comment request to create new comment when submission form has no original comment', () => {
@@ -1262,39 +1287,5 @@ describe('SessionSubmissionPageComponent', () => {
     expect(commentSpy).toHaveBeenCalledTimes(1);
     expect(commentSpy).toHaveBeenLastCalledWith(expectedId, Intent.STUDENT_SUBMISSION,
         { key: testQueryParams.key, moderatedperson: '' });
-  });
-
-  it('should autosave data to localStorage', () => {
-    const questionId = 'feedback-question-id-mcq';
-    const model: QuestionSubmissionFormModel = deepCopy(testMcqQuestionSubmissionForm);
-    model.hasResponseChangedForRecipients = new Map<string, boolean>().set('r1', true);
-    model.isTabExpandedForRecipients = new Map<string, boolean>().set('r1', true);
-    const event = { id: questionId, model };
-    const setItemSpy = jest.spyOn(Storage.prototype, 'setItem');
-
-    jest.useFakeTimers();
-    component.handleAutoSave(event);
-    jest.advanceTimersByTime(component.autoSaveDelay);
-
-    expect(setItemSpy).toHaveBeenCalled();
-    jest.useRealTimers();
-  });
-
-  it('should load autosaved data from localStorage', () => {
-    const questionId = 'feedback-question-id-mcq';
-    const savedModel: any = deepCopy(testMcqQuestionSubmissionForm);
-    savedModel.hasResponseChangedForRecipients = Array.from(new Map<string, boolean>().set('r1', true).entries());
-    savedModel.isTabExpandedForRecipients = Array.from(new Map<string, boolean>().set('r1', true).entries());
-
-    const getItemSpy = jest.spyOn(Storage.prototype, 'getItem')
-      .mockReturnValue(JSON.stringify({ [questionId]: savedModel }));
-
-    component.questionSubmissionForms = [deepCopy(testMcqQuestionSubmissionForm)];
-
-    component.loadAutoSavedData(questionId);
-
-    expect(component.questionSubmissionForms[0].hasResponseChangedForRecipients.get('r1')).toBe(true);
-    expect(component.questionSubmissionForms[0].isTabExpandedForRecipients.get('r1')).toBe(true);
-    expect(getItemSpy).toHaveBeenCalledWith('autosave');
   });
 });

--- a/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
+++ b/src/web/app/pages-session/session-submission-page/session-submission-page.component.ts
@@ -11,6 +11,7 @@ import { SavingCompleteModalComponent } from './saving-complete-modal/saving-com
 import { SessionView } from './session-view.enum';
 import { environment } from '../../../environments/environment';
 import { AuthService } from '../../../services/auth.service';
+import { AutosaveService } from '../../../services/autosave.service';
 import { CourseService } from '../../../services/course.service';
 import { DeadlineExtensionHelper } from '../../../services/deadline-extension-helper';
 import { FeedbackQuestionsService } from '../../../services/feedback-questions.service';
@@ -123,7 +124,6 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
   intent: Intent = Intent.STUDENT_SUBMISSION;
 
   questionSubmissionForms: QuestionSubmissionFormModel[] = [];
-  originalQuestionSubmissionForms: QuestionSubmissionFormModel[] = [];
 
   isSavingResponses: boolean = false;
   isSubmissionFormsDisabled: boolean = false;
@@ -151,12 +151,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
   feedbackSessionId: string | undefined = '';
   studentId: string | undefined = '';
 
-  autoSaveTimeout: any;
-  autoSaveDelay = 100; // 0.1 second delay
-
   private backendUrl: string = environment.backendUrl;
-
-  private readonly AUTOSAVE_KEY = 'autosave';
 
   constructor(private route: ActivatedRoute,
               private statusMessageService: StatusMessageService,
@@ -174,46 +169,9 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
               private navigationService: NavigationService,
               private commentService: FeedbackResponseCommentService,
               private logService: LogService,
+              private autosaveService: AutosaveService,
               @Inject(DOCUMENT) private document: any) {
     this.timezoneService.getTzVersion(); // import timezone service to load timezone data
-  }
-
-  handleAutoSave(event: { id: string, model: QuestionSubmissionFormModel }): void {
-    // Disable autosave in preview mode
-    if (this.previewAsPerson) {
-      return;
-    }
-
-    clearTimeout(this.autoSaveTimeout);
-    this.autoSaveTimeout = setTimeout(() => {
-      const savedData = this.getLocalStorageItem(this.AUTOSAVE_KEY);
-      const clonedModel = {
-        ...event.model,
-        hasResponseChangedForRecipients: Array.from(event.model.hasResponseChangedForRecipients.entries()),
-        isTabExpandedForRecipients: Array.from(event.model.isTabExpandedForRecipients.entries()),
-      };
-      savedData[event.id] = clonedModel;
-      this.setLocalStorageItem(this.AUTOSAVE_KEY, savedData);
-    }, this.autoSaveDelay);
-  }
-
-  loadAutoSavedData(questionId: string): void {
-    // Disable loading autosaved data in preview mode
-    if (this.previewAsPerson) {
-      return;
-    }
-
-    const savedData = this.getLocalStorageItem(this.AUTOSAVE_KEY);
-    const savedModel = savedData[questionId];
-
-    if (savedModel) {
-        const index = this.questionSubmissionForms.findIndex((q) => q.feedbackQuestionId === questionId);
-        if (index !== -1) {
-            savedModel.hasResponseChangedForRecipients = new Map(savedModel.hasResponseChangedForRecipients);
-            savedModel.isTabExpandedForRecipients = new Map(savedModel.isTabExpandedForRecipients);
-            this.questionSubmissionForms[index] = savedModel;
-        }
-    }
   }
 
   ngOnInit(): void {
@@ -303,6 +261,31 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
         },
       });
     });
+  }
+
+  handleAutosave(model: QuestionSubmissionFormModel): void {
+    if (this.previewAsPerson || this.isSubmissionFormsDisabled) {
+      return;
+    }
+
+    this.autosaveService
+      .setSavedFeedbackResponse(this.personEmail, model.feedbackQuestionId, model.recipientSubmissionForms);
+  }
+
+  handleClearAutosave(model: QuestionSubmissionFormModel): void {
+    if (this.previewAsPerson || this.isSubmissionFormsDisabled) {
+      return;
+    }
+    this.autosaveService.clearSavedFeedbackResponse(this.personEmail, model.feedbackQuestionId);
+  }
+
+  handleLoadAutosave(model: QuestionSubmissionFormModel): FeedbackResponseRecipientSubmissionFormModel[] | null {
+    if (this.previewAsPerson || this.isSubmissionFormsDisabled) {
+      return null;
+    }
+
+    return this.autosaveService
+      .getSavedFeedbackResponse(this.personEmail, model.feedbackQuestionId);
   }
 
   // Solution for checking partial element visibility adapted from
@@ -442,7 +425,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
           this.formattedSessionOpeningTime = this.timezoneService
               .formatToString(feedbackSession.submissionStartTimestamp, feedbackSession.timeZone, TIME_FORMAT);
 
-          this.formattedSessionClosingTime = this.getformattedSessionClosingTime(feedbackSession, TIME_FORMAT);
+          this.formattedSessionClosingTime = this.getFormattedSessionClosingTime(feedbackSession, TIME_FORMAT);
 
           this.feedbackSessionSubmissionStatus = feedbackSession.submissionStatus;
           this.feedbackSessionTimezone = feedbackSession.timeZone;
@@ -563,6 +546,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                 recipientType: feedbackQuestion.recipientType,
                 recipientList: [],
                 recipientSubmissionForms: [],
+                originalRecipientSubmissionForms: [],
 
                 questionType: feedbackQuestion.questionType,
                 questionDetails: feedbackQuestion.questionDetails,
@@ -638,24 +622,28 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
           // don't load responses in preview mode
           // generate a list of empty response box
           const formMode: QuestionSubmissionFormMode = this.getQuestionSubmissionFormModeInDefaultView(model);
-          model.recipientList.forEach((recipient: FeedbackResponseRecipient) => {
-            if (formMode === QuestionSubmissionFormMode.FLEXIBLE_RECIPIENT
-                && model.recipientSubmissionForms.length >= model.customNumberOfEntitiesToGiveFeedbackTo) {
-              return;
-            }
-
-            let recipientIdentifier: string = '';
-            if (formMode !== QuestionSubmissionFormMode.FLEXIBLE_RECIPIENT) {
-              recipientIdentifier = recipient.recipientIdentifier;
-            }
-
-            model.recipientSubmissionForms.push({
-              recipientIdentifier,
-              responseDetails: this.feedbackResponsesService.getDefaultFeedbackResponseDetails(model.questionType),
-              responseId: '',
-              isValid: true,
+          if (formMode === QuestionSubmissionFormMode.FIXED_RECIPIENT) {
+            model.recipientList.forEach((recipient: FeedbackResponseRecipient) => {
+              model.recipientSubmissionForms.push({
+                recipientIdentifier: recipient.recipientIdentifier,
+                responseDetails: this.feedbackResponsesService.getDefaultFeedbackResponseDetails(model.questionType),
+                responseId: '',
+                isValid: true,
+              });
             });
-          });
+          } else {
+            // submissionFormMode === QuestionSubmissionFormMode.FLEXIBLE_RECIPIENT
+            for (let i = 0; i < model.customNumberOfEntitiesToGiveFeedbackTo; i += 1) {
+              model.recipientSubmissionForms.push({
+                recipientIdentifier: '',
+                responseDetails: this.feedbackResponsesService.getDefaultFeedbackResponseDetails(model.questionType),
+                responseId: '',
+                isValid: true,
+              });
+            }
+          }
+
+          model.originalRecipientSubmissionForms = structuredClone(model.recipientSubmissionForms);
           model.isLoading = false;
           model.isLoaded = true;
         } else {
@@ -705,29 +693,22 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
     }).pipe(finalize(() => {
       model.isLoading = false;
       model.isLoaded = true;
-
-      this.originalQuestionSubmissionForms.push({
-        ...model,
-        hasResponseChangedForRecipients: new Map(model.hasResponseChangedForRecipients),
-        isTabExpandedForRecipients: new Map(model.isTabExpandedForRecipients),
-        recipientList: model.recipientList.map((recipient) => ({ ...recipient })),
-        recipientSubmissionForms: model.recipientSubmissionForms.map((form) => ({
-          ...form,
-          responseDetails: { ...form.responseDetails },
-          commentByGiver: form.commentByGiver ? { ...form.commentByGiver } : undefined,
-        })),
-        questionDetails: { ...model.questionDetails },
-      });
-
     }))
       .subscribe({
         next: (existingResponses: FeedbackResponsesResponse) => {
-          if (this.getQuestionSubmissionFormModeInDefaultView(model) === QuestionSubmissionFormMode.FIXED_RECIPIENT) {
+          const submissionFormMode = this.getQuestionSubmissionFormModeInDefaultView(model);
+          const savedResponses = this.handleLoadAutosave(model) ?? [];
+          const originalResponses: FeedbackResponseRecipientSubmissionFormModel[] = [];
+          const responses: FeedbackResponseRecipientSubmissionFormModel[] = [];
+
+          if (submissionFormMode === QuestionSubmissionFormMode.FIXED_RECIPIENT) {
             // need to generate a full list of submission forms
             model.recipientList.forEach((recipient: FeedbackResponseRecipient) => {
               const matchedExistingResponse: FeedbackResponse | undefined =
                   existingResponses.responses.find(
                       (response: FeedbackResponse) => response.recipientIdentifier === recipient.recipientIdentifier);
+              const matchedSavedResponse = savedResponses
+                .find((res) => res.recipientIdentifier === recipient.recipientIdentifier);
               const submissionForm: FeedbackResponseRecipientSubmissionFormModel = {
                 recipientIdentifier: recipient.recipientIdentifier,
                 responseDetails: matchedExistingResponse
@@ -735,46 +716,74 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                     : this.feedbackResponsesService.getDefaultFeedbackResponseDetails(model.questionType),
                 responseId: matchedExistingResponse ? matchedExistingResponse.feedbackResponseId : '',
                 isValid: true,
+                commentByGiver: matchedExistingResponse?.giverComment ? this.getCommentModel(
+                    matchedExistingResponse.giverComment, recipient.recipientIdentifier) : undefined,
               };
-              if (matchedExistingResponse && matchedExistingResponse.giverComment) {
-                submissionForm.commentByGiver = this.getCommentModel(
-                    matchedExistingResponse.giverComment, recipient.recipientIdentifier);
+
+              originalResponses.push(submissionForm);
+              if (matchedSavedResponse) {
+                responses.push(matchedSavedResponse);
+                model.hasResponseChangedForRecipients.set(matchedSavedResponse.recipientIdentifier, true);
+              } else {
+                responses.push(submissionForm);
               }
-              model.recipientSubmissionForms.push(submissionForm);
             });
-          }
-
-          if (this.getQuestionSubmissionFormModeInDefaultView(model)
-            === QuestionSubmissionFormMode.FLEXIBLE_RECIPIENT) {
+          } else {
+            // submissionFormMode === QuestionSubmissionFormMode.FLEXIBLE_RECIPIENT
             // need to generate limited number of submission forms
-            let numberOfRecipientSubmissionFormsNeeded: number =
-                model.customNumberOfEntitiesToGiveFeedbackTo - existingResponses.responses.length;
-
+            const matchedForms = new Set<string>();
             existingResponses.responses.forEach((response: FeedbackResponse) => {
               const submissionForm: FeedbackResponseRecipientSubmissionFormModel = {
                 recipientIdentifier: response.recipientIdentifier,
                 responseDetails: response.responseDetails,
                 responseId: response.feedbackResponseId,
                 isValid: true,
+                commentByGiver: response.giverComment ? this.getCommentModel(
+                    response.giverComment, response.recipientIdentifier) : undefined,
               };
-              if (response.giverComment) {
-                submissionForm.commentByGiver = this.getCommentModel(
-                    response.giverComment, response.recipientIdentifier);
+
+              originalResponses.push(submissionForm);
+              const matchedSavedResponse = savedResponses
+                .find((res) => res.recipientIdentifier === response.recipientIdentifier);
+              if (matchedSavedResponse) {
+                model.hasResponseChangedForRecipients.set(matchedSavedResponse.recipientIdentifier, true);
+                matchedForms.add(matchedSavedResponse.recipientIdentifier);
+                responses.push(matchedSavedResponse);
+              } else {
+                responses.push(submissionForm);
               }
-              model.recipientSubmissionForms.push(submissionForm);
+            });
+
+            savedResponses.forEach((savedResponse) => {
+              if (!matchedForms.has(savedResponse.recipientIdentifier)) {
+                responses.push(savedResponse);
+              }
             });
 
             // generate empty submission forms
-            while (numberOfRecipientSubmissionFormsNeeded > 0) {
-              model.recipientSubmissionForms.push({
+            const numOriginalFormsRequired = model.customNumberOfEntitiesToGiveFeedbackTo - originalResponses.length;
+            for (let i = 0; i < numOriginalFormsRequired; i += 1) {
+              originalResponses.push({
                 recipientIdentifier: '',
                 responseDetails: this.feedbackResponsesService.getDefaultFeedbackResponseDetails(model.questionType),
                 responseId: '',
                 isValid: true,
               });
-              numberOfRecipientSubmissionFormsNeeded -= 1;
+            }
+
+            const numFormsRequired = model.customNumberOfEntitiesToGiveFeedbackTo - responses.length;
+            for (let i = 0; i < numFormsRequired; i += 1) {
+              responses.push({
+                recipientIdentifier: '',
+                responseDetails: this.feedbackResponsesService.getDefaultFeedbackResponseDetails(model.questionType),
+                responseId: '',
+                isValid: true,
+              });
             }
           }
+
+          model.originalRecipientSubmissionForms = originalResponses;
+          model.recipientSubmissionForms = responses;
         },
         error: (resp: ErrorMessageOutput) => this.statusMessageService.showErrorToast(resp.error.message),
       });
@@ -872,7 +881,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
               intent: this.intent,
               key: this.regKey,
               moderatedperson: this.moderatedPerson,
-              singlerecipientidforsubmission: recipientId?.toString() || '',
+              singlerecipientidforsubmission: recipientId || '',
             }).pipe(
                 tap((resp: FeedbackResponses) => {
                   const responsesMap: Record<string, FeedbackResponse> = {};
@@ -898,29 +907,17 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
                         }
                       });
 
-                  const savedData = this.getLocalStorageItem(this.AUTOSAVE_KEY);
-                  delete savedData[questionSubmissionFormModel.feedbackQuestionId];
-                  this.setLocalStorageItem(this.AUTOSAVE_KEY, savedData);
+                  if (recipientId) {
+                    questionSubmissionFormModel.hasResponseChangedForRecipients.set(recipientId, false);
+                  } else {
+                    questionSubmissionFormModel.hasResponseChangedForRecipients.forEach((_, key) => {
+                      questionSubmissionFormModel.hasResponseChangedForRecipients.set(key, false);
+                    });
+                  }
 
-                  this.originalQuestionSubmissionForms.forEach((originalModel: QuestionSubmissionFormModel) => {
-                    if (originalModel.feedbackQuestionId === questionSubmissionFormModel.feedbackQuestionId) {
-                      originalModel.recipientSubmissionForms.forEach((originalRecipientSubmissionFormModel:
-                        FeedbackResponseRecipientSubmissionFormModel) => {
-                          if (responsesMap[originalRecipientSubmissionFormModel.recipientIdentifier]) {
-                            const correspondingResp: FeedbackResponse =
-                                responsesMap[originalRecipientSubmissionFormModel.recipientIdentifier];
-                            originalRecipientSubmissionFormModel.responseId = correspondingResp.feedbackResponseId;
-                            originalRecipientSubmissionFormModel.responseDetails = correspondingResp.responseDetails;
-                            originalRecipientSubmissionFormModel.recipientIdentifier =
-                              correspondingResp.recipientIdentifier;
-                          } else {
-                            originalRecipientSubmissionFormModel.responseId = '';
-                            originalRecipientSubmissionFormModel.commentByGiver = undefined;
-                          }
-                        });
-                    }
-
-                  });
+                  this.handleClearAutosave(questionSubmissionFormModel);
+                  questionSubmissionFormModel.originalRecipientSubmissionForms =
+                    structuredClone(questionSubmissionFormModel.recipientSubmissionForms);
                 }),
                 switchMap(() =>
                     forkJoin(questionSubmissionFormModel.recipientSubmissionForms
@@ -1051,7 +1048,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
     const recipientSubmissionFormModel: FeedbackResponseRecipientSubmissionFormModel =
         this.questionSubmissionForms[questionIndex].recipientSubmissionForms[responseIdx];
 
-    if (!recipientSubmissionFormModel.commentByGiver || !recipientSubmissionFormModel.commentByGiver.originalComment) {
+    if (!recipientSubmissionFormModel.commentByGiver?.originalComment) {
       return;
     }
 
@@ -1094,11 +1091,10 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
     if (event && event.visible && !questionSubmissionForm.isLoaded && !questionSubmissionForm.isLoading) {
       questionSubmissionForm.isLoading = true;
       this.loadFeedbackQuestionRecipientsForQuestion(questionSubmissionForm);
-      this.loadAutoSavedData(questionSubmissionForm.feedbackQuestionId);
     }
   }
 
-  private getformattedSessionClosingTime(feedbackSession: FeedbackSession, TIME_FORMAT: string): string {
+  private getFormattedSessionClosingTime(feedbackSession: FeedbackSession, TIME_FORMAT: string): string {
     const userSessionEndingTime = DeadlineExtensionHelper.getUserFeedbackSessionEndingTimestamp(feedbackSession);
     let formattedString = this.timezoneService.formatToString(
       userSessionEndingTime, feedbackSession.timeZone, TIME_FORMAT);
@@ -1119,22 +1115,28 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
    */
   saveResponsesForSelectedRecipientQuestions(recipientId: string,
     questionSubmissionForms: QuestionSubmissionFormModel[]): void {
-    const questionsToRecipient: Set<number> | undefined = this.recipientQuestionMap.get(recipientId);
+    const questionsToRecipient = this.recipientQuestionMap.get(recipientId);
     if (!questionsToRecipient) {
-      this.statusMessageService.showErrorToast('Failed to save response for this recipient. '
-          + 'Please switch back to "Group by Question" view to save responses.');
+      // fail silently
+      // this should not happen as the save button for recipient should not
+      // be shown if there is no question mapped to the recipient.
+      return;
     }
     const recipientQSForms = questionSubmissionForms
       .filter((questionSubmissionFormModel: QuestionSubmissionFormModel) =>
-          questionsToRecipient!.has(questionSubmissionFormModel.questionNumber));
+          questionsToRecipient.has(questionSubmissionFormModel.questionNumber));
 
     this.saveFeedbackResponses(recipientQSForms, false, recipientId);
   }
 
+  /**
+   * Reset responses for intended recipient when grouped session view is toggled
+   * and reset button for the recipient is clicked.
+   */
   resetResponsesForSelectedRecipientQuestions(recipientId: string,
     questionSubmissionForms: QuestionSubmissionFormModel[]): void {
 
-    const questionsToRecipient: Set<number> | undefined = this.recipientQuestionMap.get(recipientId);
+    const questionsToRecipient = this.recipientQuestionMap.get(recipientId);
     if (!questionsToRecipient) {
       this.statusMessageService.showErrorToast('Failed to reset response for this recipient. '
           + 'Please switch back to "Group by Question" view to reset responses.');
@@ -1145,74 +1147,48 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
     this.resetFeedbackResponses(recipientQSForms, recipientId);
   }
 
+  /**
+   * Reset responses for all recipients of the questions.
+   */
   resetFeedbackResponses(questionSubmissionForms: QuestionSubmissionFormModel[], recipientId: string | null): void {
-    const savedData = this.getLocalStorageItem(this.AUTOSAVE_KEY);
-
     questionSubmissionForms.forEach((questionSubmissionFormModel: QuestionSubmissionFormModel) => {
-      const originalSubmissionForm = this.originalQuestionSubmissionForms.find(
-        (originalModel: QuestionSubmissionFormModel) =>
-          originalModel.feedbackQuestionId === questionSubmissionFormModel.feedbackQuestionId,
-      );
+      const originalRecipientSubmissionForms = questionSubmissionFormModel.originalRecipientSubmissionForms;
 
-      if (originalSubmissionForm) {
-        if (recipientId) {
-          questionSubmissionFormModel.recipientSubmissionForms.forEach((form, index) => {
-            if (form.recipientIdentifier === recipientId) {
-              const originalForm = originalSubmissionForm.recipientSubmissionForms.find(
-                (originalRecipientForm) => originalRecipientForm.recipientIdentifier === form.recipientIdentifier,
-              );
-
-              if (originalForm) {
-                questionSubmissionFormModel.recipientSubmissionForms[index] = {
-                  ...originalForm,
-                  responseDetails: { ...originalForm.responseDetails },
-                  commentByGiver: originalForm.commentByGiver ? { ...originalForm.commentByGiver } : undefined,
-                };
-              }
+      if (recipientId) {
+        // only reset the response for the selected recipient
+        const originalForms = originalRecipientSubmissionForms
+          .filter((form) => form.recipientIdentifier === recipientId);
+        questionSubmissionFormModel.recipientSubmissionForms = questionSubmissionFormModel
+          .recipientSubmissionForms.map((form) => {
+            if (form.recipientIdentifier !== recipientId) {
+              return form;
             }
+
+            const originalForm = originalForms
+              .find((oriForm) => oriForm.recipientIdentifier === form.recipientIdentifier);
+
+            return originalForm ?? form;
           });
 
-          questionSubmissionFormModel.hasResponseChangedForRecipients.set(
-            recipientId, originalSubmissionForm.hasResponseChangedForRecipients.get(recipientId) ?? false,
-          );
-          questionSubmissionFormModel.isTabExpandedForRecipients.set(
-            recipientId, originalSubmissionForm.isTabExpandedForRecipients.get(recipientId) ?? true,
-          );
+        questionSubmissionFormModel.hasResponseChangedForRecipients.set(recipientId, false);
 
-          if (savedData[questionSubmissionFormModel.feedbackQuestionId]) {
-            const recipientIndex = savedData[questionSubmissionFormModel.feedbackQuestionId].recipientSubmissionForms
-              .findIndex((form: FeedbackResponseRecipientSubmissionFormModel) =>
-                  form.recipientIdentifier === recipientId);
-
-            if (recipientIndex !== -1) {
-              savedData[questionSubmissionFormModel.feedbackQuestionId]
-                .recipientSubmissionForms.splice(recipientIndex, 1);
-            }
-
-            if (savedData[questionSubmissionFormModel.feedbackQuestionId].recipientSubmissionForms.length === 0) {
-              delete savedData[questionSubmissionFormModel.feedbackQuestionId];
-            }
-          }
+        const hasAnyResponseChanged = Array
+          .from(questionSubmissionFormModel.hasResponseChangedForRecipients.values())
+          .some(Boolean);
+        if (hasAnyResponseChanged) {
+          this.handleAutosave(questionSubmissionFormModel);
         } else {
-          Object.assign(questionSubmissionFormModel, {
-            ...originalSubmissionForm,
-            recipientSubmissionForms: originalSubmissionForm.recipientSubmissionForms
-              .map((form: FeedbackResponseRecipientSubmissionFormModel) => ({
-                ...form,
-                responseDetails: { ...form.responseDetails },
-                commentByGiver: form.commentByGiver ? { ...form.commentByGiver } : undefined,
-              })),
-            hasResponseChangedForRecipients: new Map(originalSubmissionForm.hasResponseChangedForRecipients),
-            isTabExpandedForRecipients: new Map(originalSubmissionForm.isTabExpandedForRecipients),
-            questionDetails: { ...originalSubmissionForm.questionDetails },
-          });
-
-          delete savedData[questionSubmissionFormModel.feedbackQuestionId];
+          this.handleClearAutosave(questionSubmissionFormModel);
         }
+      } else {
+        // reset responses for all recipients
+        questionSubmissionFormModel.recipientSubmissionForms = structuredClone(originalRecipientSubmissionForms);
+        questionSubmissionFormModel.hasResponseChangedForRecipients.forEach((_, responseRecipientId) => {
+          questionSubmissionFormModel.hasResponseChangedForRecipients.set(responseRecipientId, false);
+        });
+        this.handleClearAutosave(questionSubmissionFormModel);
       }
     });
-
-    this.setLocalStorageItem(this.AUTOSAVE_KEY, savedData);
   }
 
   hasResponseChangedForRecipient(recipientId: string,
@@ -1323,7 +1299,7 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
     }
 
     const recipient: FeedbackResponseRecipient | undefined =
-        question!.recipientList.find(
+        question.recipientList.find(
             (r: FeedbackResponseRecipient) => r.recipientIdentifier === recipientIdentifier);
 
     return recipient ? recipient.recipientName : 'Unknown';
@@ -1350,19 +1326,5 @@ export class SessionSubmissionPageComponent implements OnInit, AfterViewInit {
       feedbackSessionId: this.feedbackSessionId,
       studentId: this.studentId,
     }).subscribe();
-  }
-
-  /**
-   * Utility method to get item from local storage.
-   */
-  private getLocalStorageItem(key: string): any {
-    return JSON.parse(localStorage.getItem(key) || '{}');
-  }
-
-  /**
-   * Utility method to set item in local storage.
-   */
-  private setLocalStorageItem(key: string, data: any): void {
-    localStorage.setItem(key, JSON.stringify(data));
   }
 }

--- a/src/web/services/autosave.service.spec.ts
+++ b/src/web/services/autosave.service.spec.ts
@@ -1,0 +1,186 @@
+import { AutosaveService } from './autosave.service';
+import { FeedbackResponseRecipientSubmissionFormModel } from '../app/components/question-submission-form/question-submission-form-model';
+import { FeedbackTextResponseDetails } from '../types/api-output';
+import { DEFAULT_TEXT_RESPONSE_DETAILS } from '../types/default-question-structs';
+
+describe('AutosaveService', () => {
+  let service: AutosaveService;
+  let mockLocalStorage: Record<string, string>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockLocalStorage = {};
+    Object.defineProperty(globalThis, 'localStorage', {
+      value: {
+        getItem: jest.fn((key: string) => mockLocalStorage[key] ?? null),
+        setItem: jest.fn((key: string, value: string) => {
+          mockLocalStorage[key] = value;
+        }),
+        removeItem: jest.fn((key: string) => {
+          delete mockLocalStorage[key];
+        }),
+        key: jest.fn((i: number) => Object.keys(mockLocalStorage)[i] ?? null),
+        get length() {
+          return Object.keys(mockLocalStorage).length;
+        },
+      },
+      writable: true,
+    });
+
+    service = new AutosaveService();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    mockLocalStorage = {};
+  });
+
+  it('should save and retrieve feedback response', () => {
+    const userId = 'user1';
+    const questionId = 'q1';
+    const data: FeedbackResponseRecipientSubmissionFormModel[] = [{
+      responseId: 'response-id',
+      recipientIdentifier: 'recipient-id',
+      responseDetails: DEFAULT_TEXT_RESPONSE_DETAILS(),
+      isValid: true,
+      commentByGiver: undefined,
+    }];
+
+    service.setSavedFeedbackResponse(userId, questionId, data);
+    jest.advanceTimersByTime(500);
+
+    const saved = service.getSavedFeedbackResponse(userId, questionId);
+    expect(saved).toEqual(data);
+  });
+
+  it('should clear saved feedback response', () => {
+    const userId = 'user2';
+    const questionId = 'q2';
+    const data: FeedbackResponseRecipientSubmissionFormModel[] = [{
+      responseId: 'response-id',
+      recipientIdentifier: 'recipient-id',
+      responseDetails: DEFAULT_TEXT_RESPONSE_DETAILS(),
+      isValid: true,
+      commentByGiver: undefined,
+    }];
+
+    service.setSavedFeedbackResponse(userId, questionId, data);
+    jest.advanceTimersByTime(500);
+
+    service.clearSavedFeedbackResponse(userId, questionId);
+
+    const saved = service.getSavedFeedbackResponse(userId, questionId);
+    expect(saved).toBeNull();
+  });
+
+  it('should return null for expired entry', () => {
+    const userId = 'user3';
+    const questionId = 'q3';
+    const key = `autosave_${userId}_${questionId}`;
+    const data: FeedbackResponseRecipientSubmissionFormModel[] = [{
+      responseId: 'response-id',
+      recipientIdentifier: 'recipient-id',
+      responseDetails: DEFAULT_TEXT_RESPONSE_DETAILS(),
+      isValid: true,
+      commentByGiver: undefined,
+    }];
+    const expiredPayload = {
+      value: data,
+      expiry: Date.now() - 1000,
+    };
+    mockLocalStorage[key] = JSON.stringify(expiredPayload);
+
+    const saved = service.getSavedFeedbackResponse(userId, questionId);
+    expect(saved).toBeNull();
+    expect(globalThis.localStorage.removeItem).toHaveBeenCalledWith(key);
+  });
+
+  it('should clean up expired entries on construction', () => {
+    const key = 'autosave_cleanup';
+    const data: FeedbackResponseRecipientSubmissionFormModel[] = [{
+      responseId: 'response-id',
+      recipientIdentifier: 'recipient-id',
+      responseDetails: DEFAULT_TEXT_RESPONSE_DETAILS(),
+      isValid: true,
+      commentByGiver: undefined,
+    }];
+    mockLocalStorage[key] = JSON.stringify({
+      value: data,
+      expiry: Date.now() - 1000,
+    });
+
+    service = new AutosaveService();
+    expect(globalThis.localStorage.removeItem).toHaveBeenCalledWith(key);
+  });
+
+  it('should debounce saves', () => {
+    const userId = 'user4';
+    const questionId = 'q4';
+    const data1: FeedbackResponseRecipientSubmissionFormModel[] = [{
+      responseId: 'response-id',
+      recipientIdentifier: 'recipient-id',
+      responseDetails: DEFAULT_TEXT_RESPONSE_DETAILS(),
+      isValid: true,
+      commentByGiver: undefined,
+    }];
+    const data2: FeedbackResponseRecipientSubmissionFormModel[] = [{
+      responseId: 'response-id',
+      recipientIdentifier: 'recipient-id',
+      responseDetails: DEFAULT_TEXT_RESPONSE_DETAILS(),
+      isValid: true,
+      commentByGiver: undefined,
+    }];
+    (data2[0].responseDetails as FeedbackTextResponseDetails).answer = 'updated response';
+
+    service.setSavedFeedbackResponse(userId, questionId, data1);
+    service.setSavedFeedbackResponse(userId, questionId, data2);
+
+    jest.advanceTimersByTime(500);
+
+    const saved = service.getSavedFeedbackResponse(userId, questionId);
+    expect(globalThis.localStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(saved).toEqual(data2);
+  });
+
+  it('should isolate debounce per key', () => {
+    const data1: FeedbackResponseRecipientSubmissionFormModel[] = [{
+      responseId: 'r1',
+      recipientIdentifier: 'recipient1',
+      responseDetails: DEFAULT_TEXT_RESPONSE_DETAILS(),
+      isValid: true,
+      commentByGiver: undefined,
+    }];
+
+    const data2: FeedbackResponseRecipientSubmissionFormModel[] = [{
+      responseId: 'r2',
+      recipientIdentifier: 'recipient2',
+      responseDetails: DEFAULT_TEXT_RESPONSE_DETAILS(),
+      isValid: true,
+      commentByGiver: undefined,
+    }];
+
+    service.setSavedFeedbackResponse('userA', 'q1', data1);
+    service.setSavedFeedbackResponse('userB', 'q2', data2);
+
+    jest.advanceTimersByTime(500);
+
+    const saved1 = service.getSavedFeedbackResponse('userA', 'q1');
+    const saved2 = service.getSavedFeedbackResponse('userB', 'q2');
+
+    expect(saved1).toEqual(data1);
+    expect(saved2).toEqual(data2);
+    expect(globalThis.localStorage.setItem).toHaveBeenCalledTimes(2);
+  });
+
+  it('should handle corrupted localStorage entry gracefully', () => {
+    const userId = 'user5';
+    const questionId = 'q5';
+    const key = `autosave_${userId}_${questionId}`;
+    mockLocalStorage[key] = 'not a valid json';
+
+    const saved = service.getSavedFeedbackResponse(userId, questionId);
+    expect(saved).toBeNull();
+    expect(globalThis.localStorage.removeItem).toHaveBeenCalledWith(key);
+  });
+});

--- a/src/web/services/autosave.service.ts
+++ b/src/web/services/autosave.service.ts
@@ -1,0 +1,126 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+import { debounceTime } from 'rxjs/operators';
+import { FeedbackResponseRecipientSubmissionFormModel } from '../app/components/question-submission-form/question-submission-form-model';
+
+export interface StoredValue<T> {
+  value: T;
+  expiry: number;
+}
+
+/**
+ * Service to handle autosaving of data to local storage.
+ *
+ * Saves are debounced to avoid excessive writes.
+ * Saved data automatically expires after a set time and is cleaned up on load.
+ */
+@Injectable({ providedIn: 'root' })
+export class AutosaveService {
+  private readonly PREFIX = 'autosave_';
+  private readonly DEBOUNCE_MS = 500;
+  private readonly TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+  private readonly streams = new Map<string, Subject<unknown>>();
+
+  constructor() {
+    this.cleanUpExpiredEntries();
+  }
+
+  getSavedFeedbackResponse(
+    userId: string,
+    feedbackQuestionId: string,
+  ): FeedbackResponseRecipientSubmissionFormModel[] | null {
+    const key = this.getFeedbackResponseStorageKey(userId, feedbackQuestionId);
+    return this.load<FeedbackResponseRecipientSubmissionFormModel[]>(key);
+  }
+
+  setSavedFeedbackResponse(
+    userId: string,
+    feedbackQuestionId: string,
+    data: FeedbackResponseRecipientSubmissionFormModel[],
+  ): void {
+    const key = this.getFeedbackResponseStorageKey(userId, feedbackQuestionId);
+    this.queueSave(key, data);
+  }
+
+  clearSavedFeedbackResponse(userId: string, feedbackQuestionId: string): void {
+    const key = this.getFeedbackResponseStorageKey(userId, feedbackQuestionId);
+    this.clear(key);
+  }
+
+  private cleanUpExpiredEntries(): void {
+    const keys: string[] = [];
+
+    for (let i = 0; i < localStorage.length; i += 1) {
+      const key = localStorage.key(i);
+      if (key?.startsWith(this.PREFIX)) {
+        keys.push(key);
+      }
+    }
+
+    keys.forEach((key) => this.load(key));
+  }
+
+  private queueSave(key: string, value: unknown): void {
+    if (!this.streams.has(key)) {
+      const subject = new Subject<unknown>();
+
+      subject
+        .pipe(debounceTime(this.DEBOUNCE_MS))
+        .subscribe((latestValue) => {
+          this.save(key, latestValue);
+        });
+
+      this.streams.set(key, subject);
+    }
+
+    this.streams.get(key)!.next(value);
+  }
+
+  private save<T>(key: string, value: T): void {
+    try {
+      const payload: StoredValue<T> = {
+        value,
+        expiry: Date.now() + this.TTL_MS,
+      };
+      localStorage.setItem(key, JSON.stringify(payload));
+    } catch {
+      // fail silently
+    }
+  }
+
+  private load<T>(key: string): T | null {
+    const raw = localStorage.getItem(key);
+    if (!raw) {
+      return null;
+    }
+
+    try {
+      const stored = JSON.parse(raw) as StoredValue<T>;
+
+      if (!stored?.expiry || Date.now() > stored.expiry) {
+        this.clear(key);
+        return null;
+      }
+
+      return stored.value;
+    } catch {
+      this.clear(key);
+      return null;
+    }
+  }
+
+  private clear(key: string): void {
+    const stream = this.streams.get(key);
+    if (stream) {
+      stream.complete();
+      this.streams.delete(key);
+    }
+
+    localStorage.removeItem(key);
+  }
+
+  private getFeedbackResponseStorageKey(userId: string, feedbackQuestionId: string): string {
+    return `${this.PREFIX}${userId}_${feedbackQuestionId}`;
+  }
+}


### PR DESCRIPTION
Fixes #

**Outline of Solution**

Currently, autosave logic:

1. Uses a single 'autosave' local storage key. 
2. Persist the entire `QuestionSubmissionFormModel` for questions being saved.
3. Is not correctly scoped to user.
4. Has to stale data expiration mechanism

**This approach introduces several risks**

1. Storage size risk (5 MB limit)
This increases the likelihood of exceeding the browser's localStorage limit. This could result in failed writes which are not handled well in the system. 

2. Performance concerns
Reading and writing large, deeply nested models can easily lead to performance issues. 

3. Data corruption and sync issues
Large payloads increase the likelihood of partial writes or data corruption, especially across multiple tabs and sessions, or if the feedback session is modified midway through.

4. Cross-user contamination risks
Since the key is not scoped to a particular user, stale autosaved data could potentially be applied to another user's feedback session on the same machine.

**Changes Introduced**

Introduced a autosave service to handle saving to local storage. 

- localstorage keys are now scoped as `autosave_{userId}_{questionId}`.
- We only store the FeedbackResponseRecipientSubmissionFormModel. This does not eliminate the risk of hitting local storage limit, but it does make it less probable. If out storage requirements evolve significantly, we can consider moving to IndexedDB, but for now we shall keep it simple.
- Errors not fail silently. Autosave is treated as a second class non-essential enhancement that can fail but should not block the main operations.
- TTL for stale entries, currently set to 7 days. I would actually like to set it even shorter if possible. Students should instead be encouraged to submit their in-progress work for long lived sessions, the autosave is there to guard against accidentally refresh/page navigation.

In addition, a few bugs were fixed. Notably,

- Save state now accounts for submission failures. Responses that have failed validation while saving are now not marked as saved and can be reset.
- Properly debounced writes. Previously, multiple setTimeouts were used to synchronise states. This is brittle and introduced race conditions. Now, writes to local storage are properly debounced and resets are handled appropriately.
- Autosaved responses are now properly merged with responses from DB. Previously, the entire `QuestionSubmissionFormModel` was replaced with the saved version. This means any changes to the model will not be updated properly. For example, changes in question details, changes in users to give feedback to etc.